### PR TITLE
mapDocument function

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -11,6 +11,7 @@
     "dependencies": {
         "elm/browser": "1.0.0 <= v < 2.0.0",
         "elm/core": "1.0.0 <= v < 2.0.0",
+        "elm/html": "1.0.0 <= v < 2.0.0",
         "elm/json": "1.1.3 <= v < 2.0.0",
         "elm-community/json-extra": "4.0.0 <= v < 5.0.0"
     },

--- a/src/Browser/Extra.elm
+++ b/src/Browser/Extra.elm
@@ -1,13 +1,15 @@
-module Browser.Extra exposing (viewportDecoder)
+module Browser.Extra exposing (viewportDecoder, mapDocument)
 
 {-| Convenience functionality on
 [`Browser`](http://package.elm-lang.org/packages/elm/browser/latest/Browser)-related types
 
-@docs viewportDecoder
+@docs viewportDecoder, mapDocument
 
 -}
 
+import Browser
 import Browser.Dom exposing (Viewport)
+import Html
 import Json.Decode as Decode exposing (Decoder)
 import Json.Decode.Extra as Decode
 
@@ -39,3 +41,26 @@ viewportDecoder =
         |> Decode.andMap (Decode.at [ "target", "scrollTop" ] Decode.float)
         |> Decode.andMap (Decode.at [ "target", "clientWidth" ] Decode.float)
         |> Decode.andMap (Decode.at [ "target", "clientHeight" ] Decode.float)
+
+
+{-| Map a [`Browser Document`](https://package.elm-lang.org/packages/elm/browser/latest/Browser#Document) from one `msg` type to another.
+
+    type Msg
+        = HomeMsg Home.Msg
+
+    view : Page -> Browser.Document Msg
+    view page =
+        case page of
+            Home model ->
+                mapDocument HomeMsg (Home.view model)
+
+
+    -- Home.elm
+    view : Home.Model -> Browser.Document Home.Msg
+
+-}
+mapDocument : (a -> b) -> Browser.Document a -> Browser.Document b
+mapDocument f document =
+    { title = document.title
+    , body = List.map (Html.map f) document.body
+    }


### PR DESCRIPTION
Hello!

This is a function that will map the `Msg` type for a `Browser.Document msg`. It just maps over the `Html msg` inside the `Browser.Document msg`.

Ive used this function for SPAs where each page is structurally very top-level and self contained, and has a view function that produces a `Browser.Document msg`. These pages are rendering an entire document, but they still need to be mapped into the top-level `Msg` type.